### PR TITLE
Drivers license itr2: written test

### DIFF
--- a/lib/facility.rb
+++ b/lib/facility.rb
@@ -35,4 +35,8 @@ class Facility
       @registered_vehicles << vehicle 
     end 
   end
+
+  def administer_written_test(registrant)
+    
+  end
 end

--- a/lib/facility.rb
+++ b/lib/facility.rb
@@ -37,7 +37,7 @@ class Facility
   end
 
   def administer_written_test(registrant)
-    if @services.include?('Written Test') && registrant.permit? == true
+    if @services.include?('Written Test') && registrant.permit? == true && registrant.age >= 16
       true 
       registrant.license_data[:written] = true
     else 

--- a/lib/facility.rb
+++ b/lib/facility.rb
@@ -37,7 +37,7 @@ class Facility
   end
 
   def administer_written_test(registrant)
-    if @services.include?('Written Test')
+    if @services.include?('Written Test') && registrant.permit? == true
       true 
       registrant.license_data[:written] = true
     else 

--- a/lib/facility.rb
+++ b/lib/facility.rb
@@ -37,6 +37,12 @@ class Facility
   end
 
   def administer_written_test(registrant)
-    
+    if @services.include?('Written Test')
+      true 
+      registrant.license_data[:written] = true
+    else 
+      false 
+      registrant.license_data[:written] = false
+    end
   end
 end

--- a/spec/facility_spec.rb
+++ b/spec/facility_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe Facility do
     @cruz = Vehicle.new({vin: '123456789abcdefgh', year: 2012, make: 'Chevrolet', model: 'Cruz', engine: :ice})
     @bolt = Vehicle.new({vin: '987654321abcdefgh', year: 2019, make: 'Chevrolet', model: 'Bolt', engine: :ev})
     @camaro = Vehicle.new({vin: '1a2b3c4d5e6f', year: 1969, make: 'Chevrolet', model: 'Camaro', engine: :ice})
-
+    @registrant_1 = Registrant.new('Bruce', 18, true)
+    @registrant_2 = Registrant.new('Penny', 16)
+    @registrant_3 = Registrant.new('Tucker', 15)
   end
   describe '#initialize' do
     it 'can initialize' do
@@ -59,6 +61,14 @@ RSpec.describe Facility do
       @facility_2.register_vehicle(@bolt)
       expect(@facility_2.registered_vehicles).to eq([])
       expect(@facility_2.collected_fees).to eq(0)
+    end
+  end
+
+  describe '#written test' do
+    it 'can administer written tests to get a license' do
+      expect(@registrant_1.license_data).to eq({:written=>false, :license=>false, :renewed=>false})
+      expect(@registrant_1.permit?).to eq(true)
+      expect(@facility_1.administer_written_test(@registrant_1)).to eq(false)
     end
   end
 end

--- a/spec/facility_spec.rb
+++ b/spec/facility_spec.rb
@@ -69,6 +69,9 @@ RSpec.describe Facility do
       expect(@registrant_1.license_data).to eq({:written=>false, :license=>false, :renewed=>false})
       expect(@registrant_1.permit?).to eq(true)
       expect(@facility_1.administer_written_test(@registrant_1)).to eq(false)
+      @facility_1.add_service('Written Test')
+      expect(@facility_1.administer_written_test(@registrant_1)).to eq(true)
+      expect(@registrant_1.license_data).to eq({:written=>true, :license=>false, :renewed=>false})
     end
   end
 end

--- a/spec/facility_spec.rb
+++ b/spec/facility_spec.rb
@@ -72,6 +72,13 @@ RSpec.describe Facility do
       @facility_1.add_service('Written Test')
       expect(@facility_1.administer_written_test(@registrant_1)).to eq(true)
       expect(@registrant_1.license_data).to eq({:written=>true, :license=>false, :renewed=>false})
+
+      expect(@registrant_2.age).to eq(16)
+      expect(@registrant_2.permit?).to eq(false)
+      expect(@facility_1.administer_written_test(@registrant_2)).to eq(false)
+      @registrant_2.earn_permit
+      expect(@facility_1.administer_written_test(@registrant_2)).to eq(true)
+      expect(@registrant_2.license_data).to eq({:written=>true, :license=>false, :renewed=>false})
     end
   end
 end

--- a/spec/facility_spec.rb
+++ b/spec/facility_spec.rb
@@ -79,6 +79,14 @@ RSpec.describe Facility do
       @registrant_2.earn_permit
       expect(@facility_1.administer_written_test(@registrant_2)).to eq(true)
       expect(@registrant_2.license_data).to eq({:written=>true, :license=>false, :renewed=>false})
+
+      expect(@registrant_3.age).to eq(15)
+      expect(@registrant_3.permit?).to eq(false)
+      expect(@facility_1.administer_written_test(@registrant_3)).to eq(false)
+      @registrant_3.earn_permit
+      expect(@facility_1.administer_written_test(@registrant_3)).to eq(false)
+      expect(@registrant_3.license_data).to eq({:written=>false, :license=>false, :renewed=>false})
+
     end
   end
 end


### PR DESCRIPTION
Create an administer_written_test method and add logic requiring age and permit statuses of registrants, as well as facility offering the service. Upon running method, registrants drivers license statuses will also be updated with changes to their hash key value.  