### PR TITLE
Renew license itr2

### DIFF
--- a/lib/facility.rb
+++ b/lib/facility.rb
@@ -54,4 +54,12 @@ class Facility
       registrant.license_data[:license] = false
     end
   end
+
+  def renew_drivers_license(registrant)
+    if @services.include?('Renew License')
+      true
+    else
+      false 
+    end
+  end
 end

--- a/lib/facility.rb
+++ b/lib/facility.rb
@@ -56,7 +56,7 @@ class Facility
   end
 
   def renew_drivers_license(registrant)
-    if @services.include?('Renew License')
+    if @services.include?('Renew License') && registrant.license_data[:license] == true
       true      
       registrant.license_data[:renewed] = true
     else

--- a/lib/facility.rb
+++ b/lib/facility.rb
@@ -57,9 +57,11 @@ class Facility
 
   def renew_drivers_license(registrant)
     if @services.include?('Renew License')
-      true
+      true      
+      registrant.license_data[:renewed] = true
     else
       false 
+      registrant.license_data[:renewed] = false
     end
   end
 end

--- a/spec/facility_spec.rb
+++ b/spec/facility_spec.rb
@@ -99,6 +99,10 @@ RSpec.describe Facility do
       expect(@facility_1.administer_road_test(@registrant_2)).to eq(true)
       expect(@registrant_2.license_data).to eq({:written=>true, :license=>true, :renewed=>false})
 
+      expect(@facility_1.renew_drivers_license(@registrant_1)).to eq(false)
+      @facility_1.add_service('Renew License')
+      expect(@facility_1.renew_drivers_license(@registrant_1)).to eq(true)
+      expect(@registrant_1.license_data).to eq({:written=>true, :license=>true, :renewed=>true})
     end
   end
 end

--- a/spec/facility_spec.rb
+++ b/spec/facility_spec.rb
@@ -107,7 +107,6 @@ RSpec.describe Facility do
       expect(@registrant_3.license_data).to eq({:written=>false, :license=>false, :renewed=>false})
       expect(@facility_1.renew_drivers_license(@registrant_2)).to eq(true)
       expect(@registrant_2.license_data).to eq({:written=>true, :license=>true, :renewed=>true})
-
     end
   end
 end

--- a/spec/facility_spec.rb
+++ b/spec/facility_spec.rb
@@ -103,6 +103,11 @@ RSpec.describe Facility do
       @facility_1.add_service('Renew License')
       expect(@facility_1.renew_drivers_license(@registrant_1)).to eq(true)
       expect(@registrant_1.license_data).to eq({:written=>true, :license=>true, :renewed=>true})
+      expect(@facility_1.renew_drivers_license(@registrant_3)).to eq(false)
+      expect(@registrant_3.license_data).to eq({:written=>false, :license=>false, :renewed=>false})
+      expect(@facility_1.renew_drivers_license(@registrant_2)).to eq(true)
+      expect(@registrant_2.license_data).to eq({:written=>true, :license=>true, :renewed=>true})
+
     end
   end
 end


### PR DESCRIPTION
This will complete the iteration pattern for receiving a license in iteration 2. Creating a renew_license method, and changing the registrants license_data hash key value of renewed to true upon calling the method in facility class.